### PR TITLE
fix: Make the build compatible with JDK 11+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-- oraclejdk8
+- oraclejdk11
 cache:
   directories:
   - "$HOME/.m2"

--- a/pom.xml
+++ b/pom.xml
@@ -117,8 +117,8 @@
     <vertx.utils.version>3.5.0</vertx.utils.version>
 
     <!--Other dependency versions-->
-    <junit.version>4.12</junit.version>
-    <mockito.version>2.12.0</mockito.version>
+    <junit.version>4.13</junit.version>
+    <mockito.version>3.2.4</mockito.version>
     <jackson.version>2.9.2</jackson.version>
     <netty.version>4.1.15.Final</netty.version>
 
@@ -127,6 +127,10 @@
     <jacoco.check.branch.coverage>0.7</jacoco.check.branch.coverage>
 
     <!--Plugin versions-->
+    <maven.javadoc.plugin.version>3.1.1</maven.javadoc.plugin.version>
+    <maven.jacoco.plugin.version>0.8.5</maven.jacoco.plugin.version>
+    <maven.surefire.plugin.version>2.22.2</maven.surefire.plugin.version>
+    <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
     <maven.assembly.plugin.version>2.6</maven.assembly.plugin.version>
     <maven.jxr.plugin.version>2.3</maven.jxr.plugin.version>
   </properties>
@@ -194,6 +198,17 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <version>${maven.compiler.plugin.version}</version>
+        <configuration>
+          <showDeprecation>true</showDeprecation>
+          <showWarnings>true</showWarnings>
+          <release>8</release>
+          <compilerArgs>
+            <arg>-Xlint:all</arg>
+            <arg>-Werror</arg>
+            <arg>-Xlint:-processing</arg>
+          </compilerArgs>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/src/test/java/com/groupon/vertx/redis/RedisInputStreamTest.java
+++ b/src/test/java/com/groupon/vertx/redis/RedisInputStreamTest.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2014 Groupon.com
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,10 +16,10 @@
 package com.groupon.vertx.redis;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 


### PR DESCRIPTION
To fix the error: https://travis-ci.org/groupon/vertx-redis/builds/646677170?utm_source=github_status&utm_medium=notification

```bash
$ export JAVA_HOME=~/oraclejdk8
$ export PATH="$JAVA_HOME/bin:$PATH"
$ ~/bin/install-jdk.sh --target "/home/travis/oraclejdk8" --workspace "/home/travis/.cache/install-jdk" --feature "8" --license "BCL"
Ignoring license option: BCL -- using GPLv2+CE by default
install-jdk.sh 2020-01-14
Expected feature release number in range of 9 to 15, but got: 8
The command "~/bin/install-jdk.sh --target "/home/travis/oraclejdk8" --workspace "/home/travis/.cache/install-jdk" --feature "8" --license "BCL"" failed and exited with 3 during .
```